### PR TITLE
feat: add image_dir parameter to OpenDataLoaderPDFLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ loader = OpenDataLoaderPDFLoader(
     image_output="embedded",
     image_format="jpeg"  # or "png"
 )
+
+# Save images as files to a local directory
+loader = OpenDataLoaderPDFLoader(
+    file_path="doc.pdf",
+    format="markdown",
+    image_output="external",
+    image_dir="./images",   # images saved here; defaults to temp dir if not set
+    image_format="png"
+)
 ```
 
 ### Suppress Logging
@@ -175,6 +184,7 @@ results = vectorstore.similarity_search("What is the main topic?")
 | `keep_line_breaks` | `bool` | `False` | Preserve original line breaks |
 | `image_output` | `str` | `"off"` | `"off"`, `"embedded"` (Base64), or `"external"` |
 | `image_format` | `str` | `"png"` | `"png"` or `"jpeg"` |
+| `image_dir` | `str` | `None` | Directory for extracted images when using `image_output="external"` |
 | `content_safety_off` | `List[str]` | `None` | Disable safety filters: `"hidden-text"`, `"off-page"`, `"tiny"`, `"hidden-ocg"`, `"all"` |
 | `replace_invalid_chars` | `str` | `None` | Replacement for invalid characters |
 

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -57,6 +57,7 @@ class OpenDataLoaderPDFLoader(BaseLoader):
         reading_order: Optional[str] = None,
         image_output: str = "off",
         image_format: Optional[str] = None,
+        image_dir: Optional[str] = None,
         split_pages: bool = True,
     ):
         """Initialize the loader.
@@ -82,6 +83,9 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 (Values: "off", "embedded" (Base64), "external" (file references))
             image_format: Output format for extracted images.
                 (Values: "png", "jpeg". Default: "png")
+            image_dir: Directory where extracted images are saved when using
+                image_output="external". If not set, images are saved alongside
+                the output files in a temporary directory.
             split_pages: If True, split output into separate Documents per page.
                 Automatically sets the appropriate page separator for the format.
         """
@@ -100,6 +104,7 @@ class OpenDataLoaderPDFLoader(BaseLoader):
         self.reading_order = reading_order
         self.image_output = image_output
         self.image_format = image_format
+        self.image_dir = image_dir
         self.split_pages = split_pages
 
     # Internal separator used for page splitting (unique enough to avoid collisions)
@@ -233,6 +238,7 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 html_page_separator=page_sep,
                 image_output=self.image_output,
                 image_format=self.image_format,
+                image_dir=self.image_dir,
             )
 
             if self.format == "json":

--- a/tests/test_document_loaders.py
+++ b/tests/test_document_loaders.py
@@ -73,6 +73,12 @@ class TestOpenDataLoaderPDFLoaderInit:
         assert loader.image_output == "embedded"
         assert loader.image_format == "jpeg"
 
+    def test_init_with_image_dir(self):
+        loader = OpenDataLoaderPDFLoader(
+            file_path="test.pdf", image_output="external", image_dir="./images"
+        )
+        assert loader.image_dir == "./images"
+
     def test_init_defaults_for_new_options(self):
         loader = OpenDataLoaderPDFLoader(file_path="test.pdf")
         assert loader.password is None
@@ -83,6 +89,7 @@ class TestOpenDataLoaderPDFLoaderInit:
         assert loader.reading_order is None
         assert loader.image_output == "off"
         assert loader.image_format is None
+        assert loader.image_dir is None
 
 
 class TestOpenDataLoaderPDFLoaderConvertCall:
@@ -182,6 +189,33 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
 
     @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
     @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
+    def test_convert_passes_image_dir(self, mock_mkdtemp, mock_odl):
+        mock_mkdtemp.return_value = "/tmp/test"
+        mock_odl.convert = MagicMock()
+
+        loader = OpenDataLoaderPDFLoader(
+            file_path="test.pdf", image_output="external", image_dir="./images"
+        )
+        list(loader.lazy_load())
+
+        call_kwargs = mock_odl.convert.call_args[1]
+        assert call_kwargs["image_output"] == "external"
+        assert call_kwargs["image_dir"] == "./images"
+
+    @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
+    @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
+    def test_convert_image_dir_none_by_default(self, mock_mkdtemp, mock_odl):
+        mock_mkdtemp.return_value = "/tmp/test"
+        mock_odl.convert = MagicMock()
+
+        loader = OpenDataLoaderPDFLoader(file_path="test.pdf")
+        list(loader.lazy_load())
+
+        call_kwargs = mock_odl.convert.call_args[1]
+        assert call_kwargs["image_dir"] is None
+
+    @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
+    @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
     def test_convert_passes_replace_invalid_chars(self, mock_mkdtemp, mock_odl):
         mock_mkdtemp.return_value = "/tmp/test"
         mock_odl.convert = MagicMock()
@@ -211,8 +245,9 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
             use_struct_tree=True,
             table_method="cluster",
             reading_order="xycut",
-            image_output="embedded",
+            image_output="external",
             image_format="jpeg",
+            image_dir="./images",
             split_pages=False,
         )
         list(loader.lazy_load())
@@ -228,8 +263,9 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
         assert call_kwargs["use_struct_tree"] is True
         assert call_kwargs["table_method"] == "cluster"
         assert call_kwargs["reading_order"] == "xycut"
-        assert call_kwargs["image_output"] == "embedded"
+        assert call_kwargs["image_output"] == "external"
         assert call_kwargs["image_format"] == "jpeg"
+        assert call_kwargs["image_dir"] == "./images"
 
 
 class TestOpenDataLoaderPDFLoaderValidation:


### PR DESCRIPTION
## Summary
Fixes opendataloader-project/opendataloader-pdf#243

- The underlying `opendataloader_pdf.convert()` API supports an `image_dir` parameter, but it was not exposed in `OpenDataLoaderPDFLoader`
- Users setting `image_output="external"` had no way to control where images were saved (they went to an internal temp directory)
- This adds `image_dir` as an optional parameter, consistent with all other optional parameters in the class

## Problem
When `image_output="external"`, images were written to a temporary directory created by `tempfile.mkdtemp()`. The text output referenced these temp paths, but users had no way to specify a persistent, accessible location for the image files.

## Changes
- `langchain_opendataloader_pdf/document_loaders.py` — add `image_dir: Optional[str] = None` to `__init__`, store as `self.image_dir`, pass to `convert()`
- `tests/test_document_loaders.py` — 3 new tests: init with image_dir, convert passes image_dir, default is None
- `README.md` — add `image_output="external"` + `image_dir` example in Image Handling section; add `image_dir` row to parameter table

## Approach
Simple parameter pass-through, consistent with how `image_output`, `image_format`, and all other optional parameters are handled. No validation added — the underlying engine handles invalid paths.

## How to reproduce
```python
loader = OpenDataLoaderPDFLoader(
    file_path="document.pdf",
    image_output="external",
)
docs = loader.load()
# Images are saved to a temp dir; paths in docs are inaccessible after session
```

## How to test
```python
loader = OpenDataLoaderPDFLoader(
    file_path="document.pdf",
    image_output="external",
    image_dir="./images",
)
docs = loader.load()
# Images now saved to ./images/
```

Run unit tests:
```bash
python -m pytest tests/test_document_loaders.py -v
# 40 passed
```

## Breaking changes
None