### PR TITLE
feat: update for opendataloader-pdf v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ loader = OpenDataLoaderPDFLoader(
 )
 ```
 
+### Include Headers and Footers
+
+```python
+# By default, headers and footers are excluded for cleaner RAG output
+loader = OpenDataLoaderPDFLoader(
+    file_path="document.pdf",
+    include_header_footer=True
+)
+```
+
 ### Password-Protected PDFs
 
 ```python

--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ loader = OpenDataLoaderPDFLoader(
 )
 ```
 
+### Sensitive Data Sanitization
+
+```python
+# Replace emails, phone numbers, IPs, credit cards, URLs with placeholders
+loader = OpenDataLoaderPDFLoader(
+    file_path="document.pdf",
+    sanitize=True
+)
+```
+
+### Extract Specific Pages
+
+```python
+loader = OpenDataLoaderPDFLoader(
+    file_path="document.pdf",
+    pages="1,3,5-10"
+)
+```
+
 ### Password-Protected PDFs
 
 ```python
@@ -185,6 +204,9 @@ results = vectorstore.similarity_search("What is the main topic?")
 | `image_output` | `str` | `"off"` | `"off"`, `"embedded"` (Base64), or `"external"` |
 | `image_format` | `str` | `"png"` | `"png"` or `"jpeg"` |
 | `image_dir` | `str` | `None` | Directory for extracted images when using `image_output="external"` |
+| `sanitize` | `bool` | `False` | Sanitize sensitive data (emails, phone numbers, IPs, credit cards, URLs) |
+| `pages` | `str` | `None` | Pages to extract (e.g., `"1,3,5-7"`). Default: all pages |
+| `include_header_footer` | `bool` | `False` | Include page headers and footers in output |
 | `content_safety_off` | `List[str]` | `None` | Disable safety filters: `"hidden-text"`, `"off-page"`, `"tiny"`, `"hidden-ocg"`, `"all"` |
 | `replace_invalid_chars` | `str` | `None` | Replacement for invalid characters |
 

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -58,6 +58,9 @@ class OpenDataLoaderPDFLoader(BaseLoader):
         image_output: str = "off",
         image_format: Optional[str] = None,
         image_dir: Optional[str] = None,
+        sanitize: bool = False,
+        pages: Optional[str] = None,
+        include_header_footer: bool = False,
         split_pages: bool = True,
     ):
         """Initialize the loader.
@@ -86,6 +89,10 @@ class OpenDataLoaderPDFLoader(BaseLoader):
             image_dir: Directory where extracted images are saved when using
                 image_output="external". If not set, images are saved alongside
                 the output files in a temporary directory.
+            sanitize: Enable sensitive data sanitization. Replaces emails,
+                phone numbers, IPs, credit cards, and URLs with placeholders.
+            pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages.
+            include_header_footer: Include page headers and footers in output.
             split_pages: If True, split output into separate Documents per page.
                 Automatically sets the appropriate page separator for the format.
         """
@@ -105,6 +112,9 @@ class OpenDataLoaderPDFLoader(BaseLoader):
         self.image_output = image_output
         self.image_format = image_format
         self.image_dir = image_dir
+        self.sanitize = sanitize
+        self.pages = pages
+        self.include_header_footer = include_header_footer
         self.split_pages = split_pages
 
     # Internal separator used for page splitting (unique enough to avoid collisions)
@@ -239,6 +249,9 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 image_output=self.image_output,
                 image_format=self.image_format,
                 image_dir=self.image_dir,
+                sanitize=self.sanitize,
+                pages=self.pages,
+                include_header_footer=self.include_header_footer,
             )
 
             if self.format == "json":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain-opendataloader-pdf"
-version = "0.0.0"
+version = "0.1.0"
 description = "A LangChain integration for OpenDataLoader PDF"
 authors = [{ name = "opendataloader-project", email = "open.dataloader@hancom.com" }]
 requires-python = ">=3.10,<4.0"
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "langchain-core>=1.0,<2.0",
-    "opendataloader-pdf>=1.5.1",
+    "opendataloader-pdf>=2.0.0",
 ]
 
 [project.urls]

--- a/tests/test_document_loaders.py
+++ b/tests/test_document_loaders.py
@@ -79,6 +79,20 @@ class TestOpenDataLoaderPDFLoaderInit:
         )
         assert loader.image_dir == "./images"
 
+    def test_init_with_sanitize(self):
+        loader = OpenDataLoaderPDFLoader(file_path="test.pdf", sanitize=True)
+        assert loader.sanitize is True
+
+    def test_init_with_pages(self):
+        loader = OpenDataLoaderPDFLoader(file_path="test.pdf", pages="1,3,5-7")
+        assert loader.pages == "1,3,5-7"
+
+    def test_init_with_include_header_footer(self):
+        loader = OpenDataLoaderPDFLoader(
+            file_path="test.pdf", include_header_footer=True
+        )
+        assert loader.include_header_footer is True
+
     def test_init_defaults_for_new_options(self):
         loader = OpenDataLoaderPDFLoader(file_path="test.pdf")
         assert loader.password is None
@@ -90,6 +104,9 @@ class TestOpenDataLoaderPDFLoaderInit:
         assert loader.image_output == "off"
         assert loader.image_format is None
         assert loader.image_dir is None
+        assert loader.sanitize is False
+        assert loader.pages is None
+        assert loader.include_header_footer is False
 
 
 class TestOpenDataLoaderPDFLoaderConvertCall:
@@ -230,6 +247,44 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
 
     @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
     @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
+    def test_convert_passes_sanitize(self, mock_mkdtemp, mock_odl):
+        mock_mkdtemp.return_value = "/tmp/test"
+        mock_odl.convert = MagicMock()
+
+        loader = OpenDataLoaderPDFLoader(file_path="test.pdf", sanitize=True)
+        list(loader.lazy_load())
+
+        call_kwargs = mock_odl.convert.call_args[1]
+        assert call_kwargs["sanitize"] is True
+
+    @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
+    @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
+    def test_convert_passes_pages(self, mock_mkdtemp, mock_odl):
+        mock_mkdtemp.return_value = "/tmp/test"
+        mock_odl.convert = MagicMock()
+
+        loader = OpenDataLoaderPDFLoader(file_path="test.pdf", pages="1,3")
+        list(loader.lazy_load())
+
+        call_kwargs = mock_odl.convert.call_args[1]
+        assert call_kwargs["pages"] == "1,3"
+
+    @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
+    @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
+    def test_convert_passes_include_header_footer(self, mock_mkdtemp, mock_odl):
+        mock_mkdtemp.return_value = "/tmp/test"
+        mock_odl.convert = MagicMock()
+
+        loader = OpenDataLoaderPDFLoader(
+            file_path="test.pdf", include_header_footer=True
+        )
+        list(loader.lazy_load())
+
+        call_kwargs = mock_odl.convert.call_args[1]
+        assert call_kwargs["include_header_footer"] is True
+
+    @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
+    @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
     def test_convert_passes_all_options_together(self, mock_mkdtemp, mock_odl):
         mock_mkdtemp.return_value = "/tmp/test"
         mock_odl.convert = MagicMock()
@@ -248,6 +303,9 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
             image_output="external",
             image_format="jpeg",
             image_dir="./images",
+            sanitize=True,
+            pages="1,3,5-7",
+            include_header_footer=True,
             split_pages=False,
         )
         list(loader.lazy_load())
@@ -266,6 +324,9 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
         assert call_kwargs["image_output"] == "external"
         assert call_kwargs["image_format"] == "jpeg"
         assert call_kwargs["image_dir"] == "./images"
+        assert call_kwargs["sanitize"] is True
+        assert call_kwargs["pages"] == "1,3,5-7"
+        assert call_kwargs["include_header_footer"] is True
 
 
 class TestOpenDataLoaderPDFLoaderValidation:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -178,6 +178,44 @@ class TestIntegrationWithOptions:
         documents = loader.load()
         assert len(documents) == 1
 
+    def test_load_with_sanitize(self, sample_pdf: Path):
+        """Test loading with sanitize option."""
+        loader = OpenDataLoaderPDFLoader(
+            file_path=str(sample_pdf),
+            format="text",
+            quiet=True,
+            sanitize=True,
+        )
+        documents = loader.load()
+        assert len(documents) == 1
+
+    def test_load_with_pages(self, multi_page_pdf: Path):
+        """Test loading with pages option to extract specific pages."""
+        if not multi_page_pdf.exists():
+            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
+
+        loader = OpenDataLoaderPDFLoader(
+            file_path=str(multi_page_pdf),
+            format="text",
+            quiet=True,
+            pages="1",
+            split_pages=True,
+        )
+        documents = loader.load()
+        assert len(documents) == 1
+        assert documents[0].metadata["page"] == 1
+
+    def test_load_with_include_header_footer(self, sample_pdf: Path):
+        """Test loading with include_header_footer option."""
+        loader = OpenDataLoaderPDFLoader(
+            file_path=str(sample_pdf),
+            format="text",
+            quiet=True,
+            include_header_footer=True,
+        )
+        documents = loader.load()
+        assert len(documents) == 1
+
     def test_load_multiple_files(self, sample_pdfs: list[Path]):
         """Test loading multiple PDF files."""
         if len(sample_pdfs) < 2:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -51,7 +51,9 @@ def sample_pdf() -> Path:
 
 @pytest.fixture
 def multi_page_pdf() -> Path:
-    """Return the path to a multi-page PDF file."""
+    """Return the path to a multi-page PDF file. Skips test if not found."""
+    if not MULTI_PAGE_PDF.exists():
+        pytest.skip(f"Multi-page PDF not found: {MULTI_PAGE_PDF}")
     return MULTI_PAGE_PDF
 
 
@@ -191,8 +193,6 @@ class TestIntegrationWithOptions:
 
     def test_load_with_pages(self, multi_page_pdf: Path):
         """Test loading with pages option to extract specific pages."""
-        if not multi_page_pdf.exists():
-            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
 
         loader = OpenDataLoaderPDFLoader(
             file_path=str(multi_page_pdf),
@@ -272,8 +272,6 @@ class TestIntegrationSplitPages:
 
     def test_split_pages_text_format(self, multi_page_pdf: Path):
         """Test split_pages with text format on multi-page PDF."""
-        if not multi_page_pdf.exists():
-            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
 
         loader = OpenDataLoaderPDFLoader(
             file_path=str(multi_page_pdf),
@@ -293,8 +291,6 @@ class TestIntegrationSplitPages:
 
     def test_split_pages_markdown_format(self, multi_page_pdf: Path):
         """Test split_pages with markdown format on multi-page PDF."""
-        if not multi_page_pdf.exists():
-            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
 
         loader = OpenDataLoaderPDFLoader(
             file_path=str(multi_page_pdf),
@@ -311,8 +307,6 @@ class TestIntegrationSplitPages:
 
     def test_split_pages_json_format(self, multi_page_pdf: Path):
         """Test split_pages with JSON format extracts text per page."""
-        if not multi_page_pdf.exists():
-            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
 
         loader = OpenDataLoaderPDFLoader(
             file_path=str(multi_page_pdf),
@@ -331,8 +325,6 @@ class TestIntegrationSplitPages:
 
     def test_split_pages_html_format(self, multi_page_pdf: Path):
         """Test split_pages with HTML format on multi-page PDF."""
-        if not multi_page_pdf.exists():
-            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
 
         loader = OpenDataLoaderPDFLoader(
             file_path=str(multi_page_pdf),
@@ -349,8 +341,6 @@ class TestIntegrationSplitPages:
 
     def test_split_pages_page_numbers_sequential(self, multi_page_pdf: Path):
         """Test that page numbers are sequential on multi-page PDF."""
-        if not multi_page_pdf.exists():
-            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
 
         loader = OpenDataLoaderPDFLoader(
             file_path=str(multi_page_pdf),
@@ -368,8 +358,6 @@ class TestIntegrationSplitPages:
 
     def test_split_pages_false_returns_single_document(self, multi_page_pdf: Path):
         """Test that split_pages=False returns a single document per file."""
-        if not multi_page_pdf.exists():
-            pytest.skip(f"Multi-page PDF not found: {multi_page_pdf}")
 
         loader = OpenDataLoaderPDFLoader(
             file_path=str(multi_page_pdf),

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "langchain-opendataloader-pdf"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
@@ -256,7 +256,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", specifier = ">=1.0,<2.0" },
-    { name = "opendataloader-pdf", specifier = ">=1.5.1" },
+    { name = "opendataloader-pdf", specifier = ">=2.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -283,10 +283,10 @@ wheels = [
 
 [[package]]
 name = "opendataloader-pdf"
-version = "1.5.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/f8/4087dfb3c78eec521946955856abd087a7b394588a6762a5df4e7f66d9aa/opendataloader_pdf-1.5.1-py3-none-any.whl", hash = "sha256:198724bfad10286423a44553d99bafb094dc0763c29a21d8e27f85cfe486d0f6", size = 20916081, upload-time = "2025-12-22T09:35:28.495Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5f/c97ee55c1c78b96cc65172106123a6dd27e87d8d062c4e3134dc400c3531/opendataloader_pdf-2.0.0-py3-none-any.whl", hash = "sha256:18093fa87a3089abdba14043c187f85c6a4af48c4597710de32d90e95666313e", size = 22271532, upload-time = "2026-03-11T05:13:30.854Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `opendataloader-pdf` minimum dependency from `>=1.5.1` to `>=2.0.0`
- Expose three new v2.0 parameters in `OpenDataLoaderPDFLoader`:
  - `sanitize` — replace PII (emails, phone numbers, IPs, credit cards, URLs) with placeholders
  - `pages` — extract specific pages (e.g., `"1,3,5-7"`)
  - `include_header_footer` — opt in to include page headers/footers in output
- Bump package version from `0.0.0` to `0.1.0`
- Update README with new parameter docs and usage examples
- Add unit tests (init + convert passthrough) and integration tests for all three parameters
- Also fixes latent bug where `image_dir` was passed to `convert()` but didn't exist in v1.5.1

## Test plan

- [x] Unit tests: 46 passed (`pytest tests/test_document_loaders.py`)
- [x] Integration tests: 22 passed (`pytest tests/test_integration.py`)
- [ ] Verify `sanitize=True` masks PII in output on a real PDF with email/phone content
- [ ] Verify `pages="1"` returns only page 1 on a multi-page PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)