### PR TITLE
fix: align docstrings and docs with pass-through default pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 - **Breaking**: Minimum dependency bumped to `opendataloader-pdf>=2.1.0` (was `>=2.0.0`) for `detect_strikethrough` support
+- **Behavior**: `lazy_load()` now re-raises output-processing exceptions instead of silently swallowing them — callers may observe `Exception` from document post-processing
 - `split_pages` parameter moved after synced params block (keyword-only usage unaffected)
 - `hybrid_timeout` default: `None` (pass-through to core engine, which defaults to 30000ms / 30 seconds)
 - README AI-AGENT-SUMMARY license: MIT → Apache-2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - pytest-socket for network isolation in unit tests
 
 ### Changed
+- **Breaking**: Minimum dependency bumped to `opendataloader-pdf>=2.1.0` (was `>=2.0.0`) for `detect_strikethrough` support
 - `split_pages` parameter moved after synced params block (keyword-only usage unaffected)
-- `hybrid_timeout` default documented as `"0"` (no timeout), was `"30000"`
+- `hybrid_timeout` default: `None` (pass-through to core engine, which defaults to 30000ms / 30 seconds)
 - README AI-AGENT-SUMMARY license: MIT → Apache-2.0
 - README Parameters Reference table now auto-generated from options.json
 

--- a/README.md
+++ b/README.md
@@ -235,29 +235,27 @@ results = vectorstore.similarity_search("What is the main topic?")
 |-----------|------|---------|-------------|
 | `file_path` | `str \| List[str]` | — | **(Required)** PDF file path(s) or directories |
 | `split_pages` | `bool` | `True` | Split into separate Documents per page |
-<!-- BEGIN SYNCED PARAMS TABLE -->
-| `format` | `str` | `text` | Output format. Values: text, markdown, json, html. Default: text |
+| `format` | `str` | `"text"` | Output format. Values: text, markdown, json, html |
 | `quiet` | `bool` | `False` | Suppress console logging output |
 | `content_safety_off` | `List[str]` | `None` | Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg |
 | `password` | `str` | `None` | Password for encrypted PDF files |
 | `keep_line_breaks` | `bool` | `False` | Preserve original line breaks in extracted text |
-| `replace_invalid_chars` | `str` | `" "` | Replacement character for invalid/unrecognized characters. Default: space |
+| `replace_invalid_chars` | `str` | `None` | Replacement character for invalid/unrecognized characters. Core engine defaults to space when not set |
 | `use_struct_tree` | `bool` | `False` | Use PDF structure tree (tagged PDF) for reading order and semantic structure |
-| `table_method` | `str` | `"default"` | Table detection method. Values: default (border-based), cluster (border + cluster). Default: default |
-| `reading_order` | `str` | `"xycut"` | Reading order algorithm. Values: off, xycut. Default: xycut |
-| `image_output` | `str` | `off` | Image output mode. Values: off (no images), embedded (Base64), external (file references). Default: off |
-| `image_format` | `str` | `"png"` | Output format for extracted images. Values: png, jpeg. Default: png |
+| `table_method` | `str` | `None` | Table detection method. Values: default (border-based), cluster (border + cluster). Core engine defaults to "default" |
+| `reading_order` | `str` | `None` | Reading order algorithm. Values: off, xycut. Core engine defaults to "xycut" |
+| `image_output` | `str` | `"off"` | Image output mode. Values: off (no images), embedded (Base64), external (file references) |
+| `image_format` | `str` | `None` | Output format for extracted images. Values: png, jpeg. Core engine defaults to "png" |
 | `image_dir` | `str` | `None` | Directory for extracted images |
 | `sanitize` | `bool` | `False` | Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders |
 | `pages` | `str` | `None` | Pages to extract (e.g., "1,3,5-7"). Default: all pages |
 | `include_header_footer` | `bool` | `False` | Include page headers and footers in output |
 | `detect_strikethrough` | `bool` | `False` | Detect strikethrough text and wrap with ~~ in Markdown output (experimental) |
-| `hybrid` | `str` | `"off"` | Hybrid backend (requires a running server). Quick start: pip install "opendataloader-pdf[hybrid]" && opendataloader-pdf-hybrid --port 5002. For remote servers use --hybrid-url. Values: off (default), docling-fast |
-| `hybrid_mode` | `str` | `"auto"` | Hybrid triage mode. Values: auto (default, dynamic triage), full (skip triage, all pages to backend) |
+| `hybrid` | `str` | `None` | Hybrid backend. None = Java-only (default). Values: "docling-fast". Requires a running hybrid backend server |
+| `hybrid_mode` | `str` | `None` | Hybrid triage mode. None = core engine uses "auto" internally. Values: auto (dynamic triage), full (all pages to backend) |
 | `hybrid_url` | `str` | `None` | Hybrid backend server URL (overrides default) |
-| `hybrid_timeout` | `str` | `"0"` | Hybrid backend request timeout in milliseconds (0 = no timeout). Default: 0 |
+| `hybrid_timeout` | `str` | `None` | Hybrid backend request timeout in milliseconds. Core engine defaults to 30000ms (30 seconds) |
 | `hybrid_fallback` | `bool` | `False` | Opt in to Java fallback on hybrid backend error (default: disabled) |
-<!-- END SYNCED PARAMS TABLE -->
 
 ## Document Metadata
 

--- a/README.md
+++ b/README.md
@@ -237,24 +237,24 @@ results = vectorstore.similarity_search("What is the main topic?")
 | `split_pages` | `bool` | `True` | Split into separate Documents per page |
 | `format` | `str` | `"text"` | Output format. Values: text, markdown, json, html |
 | `quiet` | `bool` | `False` | Suppress console logging output |
-| `content_safety_off` | `List[str]` | `None` | Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg |
-| `password` | `str` | `None` | Password for encrypted PDF files |
+| `content_safety_off` | `Optional[List[str]]` | `None` | Disable content safety filters. Values: all, hidden-text, off-page, tiny, hidden-ocg |
+| `password` | `Optional[str]` | `None` | Password for encrypted PDF files |
 | `keep_line_breaks` | `bool` | `False` | Preserve original line breaks in extracted text |
-| `replace_invalid_chars` | `str` | `None` | Replacement character for invalid/unrecognized characters. Core engine defaults to space when not set |
+| `replace_invalid_chars` | `Optional[str]` | `None` | Replacement character for invalid/unrecognized characters. Core engine defaults to space when not set |
 | `use_struct_tree` | `bool` | `False` | Use PDF structure tree (tagged PDF) for reading order and semantic structure |
-| `table_method` | `str` | `None` | Table detection method. Values: default (border-based), cluster (border + cluster). Core engine defaults to "default" |
-| `reading_order` | `str` | `None` | Reading order algorithm. Values: off, xycut. Core engine defaults to "xycut" |
+| `table_method` | `Optional[str]` | `None` | Table detection method. Values: default (border-based), cluster (border + cluster). Core engine defaults to "default" |
+| `reading_order` | `Optional[str]` | `None` | Reading order algorithm. Values: off, xycut. Core engine defaults to "xycut" |
 | `image_output` | `str` | `"off"` | Image output mode. Values: off (no images), embedded (Base64), external (file references) |
-| `image_format` | `str` | `None` | Output format for extracted images. Values: png, jpeg. Core engine defaults to "png" |
-| `image_dir` | `str` | `None` | Directory for extracted images |
+| `image_format` | `Optional[str]` | `None` | Output format for extracted images. Values: png, jpeg. Core engine defaults to "png" |
+| `image_dir` | `Optional[str]` | `None` | Directory for extracted images |
 | `sanitize` | `bool` | `False` | Enable sensitive data sanitization. Replaces emails, phone numbers, IPs, credit cards, and URLs with placeholders |
-| `pages` | `str` | `None` | Pages to extract (e.g., "1,3,5-7"). Default: all pages |
+| `pages` | `Optional[str]` | `None` | Pages to extract (e.g., "1,3,5-7"). Default: all pages |
 | `include_header_footer` | `bool` | `False` | Include page headers and footers in output |
 | `detect_strikethrough` | `bool` | `False` | Detect strikethrough text and wrap with ~~ in Markdown output (experimental) |
-| `hybrid` | `str` | `None` | Hybrid backend. None = Java-only (default). Values: "docling-fast". Requires a running hybrid backend server |
-| `hybrid_mode` | `str` | `None` | Hybrid triage mode. None = core engine uses "auto" internally. Values: auto (dynamic triage), full (all pages to backend) |
-| `hybrid_url` | `str` | `None` | Hybrid backend server URL (overrides default) |
-| `hybrid_timeout` | `str` | `None` | Hybrid backend request timeout in milliseconds. Core engine defaults to 30000ms (30 seconds) |
+| `hybrid` | `Optional[str]` | `None` | Hybrid backend. None = Java-only (default). Values: "docling-fast". Requires a running hybrid backend server |
+| `hybrid_mode` | `Optional[str]` | `None` | Hybrid triage mode. None = core engine uses "auto" internally. Values: auto (dynamic triage), full (all pages to backend) |
+| `hybrid_url` | `Optional[str]` | `None` | Hybrid backend server URL (overrides default) |
+| `hybrid_timeout` | `Optional[str]` | `None` | Hybrid backend request timeout in milliseconds. Core engine defaults to 30000ms (30 seconds) |
 | `hybrid_fallback` | `bool` | `False` | Opt in to Java fallback on hybrid backend error (default: disabled) |
 
 ## Document Metadata

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ results = vectorstore.similarity_search("What is the main topic?")
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `file_path` | `str \| List[str]` | — | **(Required)** PDF file path(s) or directories |
+| `file_path` | `str \| Path \| List[str \| Path]` | — | **(Required)** PDF file path(s) or directories |
 | `split_pages` | `bool` | `True` | Split into separate Documents per page |
 | `format` | `str` | `"text"` | Output format. Values: text, markdown, json, html |
 | `quiet` | `bool` | `False` | Suppress console logging output |

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -257,7 +257,7 @@ class OpenDataLoaderPDFLoader(BaseLoader):
         try:
             output_dir = tempfile.mkdtemp()
         except OSError as e:
-            logger.error(f"Failed to create temp directory: {e}")
+            logger.error("Failed to create temp directory: %s", e)
             return
 
         try:
@@ -306,8 +306,8 @@ class OpenDataLoaderPDFLoader(BaseLoader):
             except Exception as e:
                 if self.hybrid:
                     raise
-                logger.error(f"Error during conversion: {e}")
-                return
+                logger.error("Error during conversion: %s", e)
+                return  # exits generator; finally still cleans up output_dir
 
             ext_map = {"json": "json", "text": "txt", "html": "html", "markdown": "md"}
             ext = ext_map.get(self.format)
@@ -348,4 +348,7 @@ class OpenDataLoaderPDFLoader(BaseLoader):
             logger.debug("Error processing output files", exc_info=True)
             raise
         finally:
-            shutil.rmtree(output_dir, ignore_errors=True)
+            # Skip cleanup when external images are stored in the temp dir,
+            # otherwise callers would get dangling file-path references.
+            if not (self.image_output == "external" and self.image_dir is None):
+                shutil.rmtree(output_dir, ignore_errors=True)

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -247,49 +247,49 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 f"Invalid format '{self.format}'. Valid options are: 'json', 'text', 'html', 'markdown'"
             )
 
-        try:
-            output_dir = tempfile.mkdtemp(dir=tempfile.gettempdir())
-
-            # Get page separator for split_pages mode
-            page_sep = self._get_page_separator()
-
-            opendataloader_pdf.convert(
-                input_path=self.file_paths,
-                output_dir=output_dir,
-                # --- BEGIN SYNCED CONVERT KWARGS ---
-                format=[self.format],
-                quiet=self.quiet,
-                content_safety_off=self.content_safety_off,
-                password=self.password,
-                keep_line_breaks=self.keep_line_breaks,
-                replace_invalid_chars=self.replace_invalid_chars,
-                use_struct_tree=self.use_struct_tree,
-                table_method=self.table_method,
-                reading_order=self.reading_order,
-                image_output=self.image_output,
-                image_format=self.image_format,
-                image_dir=self.image_dir,
-                sanitize=self.sanitize,
-                pages=self.pages,
-                include_header_footer=self.include_header_footer,
-                detect_strikethrough=self.detect_strikethrough,
-                hybrid=self.hybrid,
-                hybrid_mode=self.hybrid_mode,
-                hybrid_url=self.hybrid_url,
-                hybrid_timeout=self.hybrid_timeout,
-                hybrid_fallback=self.hybrid_fallback,
-                # --- END SYNCED CONVERT KWARGS ---
-                markdown_page_separator=page_sep,
-                text_page_separator=page_sep,
-                html_page_separator=page_sep,
-            )
-        except Exception as e:
-            if self.hybrid:
-                raise
-            logger.error(f"Error during conversion: {e}")
-            return
+        output_dir = tempfile.mkdtemp(dir=tempfile.gettempdir())
 
         try:
+            try:
+                # Get page separator for split_pages mode
+                page_sep = self._get_page_separator()
+
+                opendataloader_pdf.convert(
+                    input_path=self.file_paths,
+                    output_dir=output_dir,
+                    # --- BEGIN SYNCED CONVERT KWARGS ---
+                    format=[self.format],
+                    quiet=self.quiet,
+                    content_safety_off=self.content_safety_off,
+                    password=self.password,
+                    keep_line_breaks=self.keep_line_breaks,
+                    replace_invalid_chars=self.replace_invalid_chars,
+                    use_struct_tree=self.use_struct_tree,
+                    table_method=self.table_method,
+                    reading_order=self.reading_order,
+                    image_output=self.image_output,
+                    image_format=self.image_format,
+                    image_dir=self.image_dir,
+                    sanitize=self.sanitize,
+                    pages=self.pages,
+                    include_header_footer=self.include_header_footer,
+                    detect_strikethrough=self.detect_strikethrough,
+                    hybrid=self.hybrid,
+                    hybrid_mode=self.hybrid_mode,
+                    hybrid_url=self.hybrid_url,
+                    hybrid_timeout=self.hybrid_timeout,
+                    hybrid_fallback=self.hybrid_fallback,
+                    # --- END SYNCED CONVERT KWARGS ---
+                    markdown_page_separator=page_sep,
+                    text_page_separator=page_sep,
+                    html_page_separator=page_sep,
+                )
+            except Exception as e:
+                if self.hybrid:
+                    raise
+                logger.error(f"Error during conversion: {e}")
+                return
+
             ext_map = {"json": "json", "text": "txt", "html": "html", "markdown": "md"}
             ext = ext_map.get(self.format)
             if ext is None:
@@ -323,13 +323,10 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                             **({"hybrid": self.hybrid} if self.hybrid else {}),
                         },
                     )
-                try:
-                    file.unlink()
-                except Exception as e:
-                    # Temp file cleanup failure is non-fatal; log and continue
-                    logger.error(f"Error deleting temp file '{file}': {e}")
-
         except Exception as e:
             # Output processing failure is fatal; re-raise so callers see it
             logger.exception("Error processing output files")
             raise
+        finally:
+            import shutil
+            shutil.rmtree(output_dir, ignore_errors=True)

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -254,7 +254,11 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 f"Invalid format '{self.format}'. Valid options are: 'json', 'text', 'html', 'markdown'"
             )
 
-        output_dir = tempfile.mkdtemp(dir=tempfile.gettempdir())
+        try:
+            output_dir = tempfile.mkdtemp()
+        except OSError as e:
+            logger.error(f"Failed to create temp directory: {e}")
+            return
 
         try:
             try:
@@ -339,8 +343,9 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                         },
                     )
         except Exception as e:
-            # Output processing failure is fatal; re-raise so callers see it
-            logger.exception("Error processing output files")
+            # Output processing failure is fatal; re-raise so callers handle it.
+            # Use debug level to avoid double-logging if caller also logs.
+            logger.debug("Error processing output files", exc_info=True)
             raise
         finally:
             shutil.rmtree(output_dir, ignore_errors=True)

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -331,5 +331,5 @@ class OpenDataLoaderPDFLoader(BaseLoader):
 
         except Exception as e:
             # Output processing failure is fatal; re-raise so callers see it
-            logger.error(f"Error processing output files: {e}")
+            logger.exception("Error processing output files")
             raise

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -79,14 +79,16 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 (Valid options are: "json", "text", "html", "markdown")
             quiet: Suppress CLI logging output. Default: False
             content_safety_off: List of content safety filters to disable.
+                Default: None (no filters disabled).
                 (Values: "all", "hidden-text", "off-page", "tiny", "hidden-ocg")
-            password: Password for encrypted PDF files.
+            password: Password for encrypted PDF files. Default: None.
             keep_line_breaks: Preserve original line breaks in extracted text.
             replace_invalid_chars: Replacement character for invalid/unrecognized
                 characters. Default: None (core engine defaults to space)
             use_struct_tree: Use PDF structure tree (tagged PDF) for reading order
                 and semantic structure.
-            table_method: Table detection method.
+            table_method: Table detection method. Default: None, core engine
+                defaults to "default".
                 (Values: "default" (border-based), "cluster" (border + cluster))
             reading_order: Reading order algorithm.
                 (Values: "off", "xycut". Default: None, core engine defaults to "xycut")
@@ -95,8 +97,8 @@ class OpenDataLoaderPDFLoader(BaseLoader):
             image_format: Output format for extracted images.
                 (Values: "png", "jpeg". Default: None, core engine defaults to "png")
             image_dir: Directory where extracted images are saved when using
-                image_output="external". If not set, images are saved alongside
-                the output files in a temporary directory.
+                image_output="external". Default: None (images saved alongside
+                output files in a temporary directory).
             sanitize: Enable sensitive data sanitization. Replaces emails,
                 phone numbers, IPs, credit cards, and URLs with placeholders.
             pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages.
@@ -109,7 +111,8 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 (core engine uses "auto" internally when not specified).
                 "auto": route only complex pages to backend.
                 "full": route all pages to backend.
-            hybrid_url: Custom backend server URL. Default: http://localhost:5002
+            hybrid_url: Custom backend server URL. Default: None (core engine
+                defaults to http://localhost:5002).
             hybrid_timeout: Backend request timeout in milliseconds (as string).
                 Default: None (core engine defaults to 30000ms / 30 seconds).
             hybrid_fallback: Opt-in to Java fallback on backend failure.
@@ -323,8 +326,10 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 try:
                     file.unlink()
                 except Exception as e:
+                    # Temp file cleanup failure is non-fatal; log and continue
                     logger.error(f"Error deleting temp file '{file}': {e}")
 
         except Exception as e:
+            # Output processing failure is fatal; re-raise so callers see it
             logger.error(f"Error processing output files: {e}")
             raise

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -83,17 +83,17 @@ class OpenDataLoaderPDFLoader(BaseLoader):
             password: Password for encrypted PDF files.
             keep_line_breaks: Preserve original line breaks in extracted text.
             replace_invalid_chars: Replacement character for invalid/unrecognized
-                characters. Default: space
+                characters. Default: None (core engine defaults to space)
             use_struct_tree: Use PDF structure tree (tagged PDF) for reading order
                 and semantic structure.
             table_method: Table detection method.
                 (Values: "default" (border-based), "cluster" (border + cluster))
             reading_order: Reading order algorithm.
-                (Values: "off", "xycut". Default: "xycut")
+                (Values: "off", "xycut". Default: None, core engine defaults to "xycut")
             image_output: Image output mode. Default: "off" (no images extracted).
                 (Values: "off", "embedded" (Base64), "external" (file references))
             image_format: Output format for extracted images.
-                (Values: "png", "jpeg". Default: "png")
+                (Values: "png", "jpeg". Default: None, core engine defaults to "png")
             image_dir: Directory where extracted images are saved when using
                 image_output="external". If not set, images are saved alongside
                 the output files in a temporary directory.
@@ -111,7 +111,7 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 "full": route all pages to backend.
             hybrid_url: Custom backend server URL. Default: http://localhost:5002
             hybrid_timeout: Backend request timeout in milliseconds (as string).
-                Default: "0" (no timeout).
+                Default: None (core engine defaults to 30000ms / 30 seconds).
             hybrid_fallback: Opt-in to Java fallback on backend failure.
                 Default: False.
         """
@@ -326,4 +326,5 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                     logger.error(f"Error deleting temp file '{file}': {e}")
 
         except Exception as e:
-            logger.error(f"Error: {e}")
+            logger.error(f"Error processing output files: {e}")
+            raise

--- a/langchain_opendataloader_pdf/document_loaders.py
+++ b/langchain_opendataloader_pdf/document_loaders.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import shutil
 import tempfile
 from collections import defaultdict
 from pathlib import Path
@@ -83,10 +84,11 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 (Values: "all", "hidden-text", "off-page", "tiny", "hidden-ocg")
             password: Password for encrypted PDF files. Default: None.
             keep_line_breaks: Preserve original line breaks in extracted text.
+                Default: False.
             replace_invalid_chars: Replacement character for invalid/unrecognized
                 characters. Default: None (core engine defaults to space)
             use_struct_tree: Use PDF structure tree (tagged PDF) for reading order
-                and semantic structure.
+                and semantic structure. Default: False.
             table_method: Table detection method. Default: None, core engine
                 defaults to "default".
                 (Values: "default" (border-based), "cluster" (border + cluster))
@@ -99,12 +101,17 @@ class OpenDataLoaderPDFLoader(BaseLoader):
             image_dir: Directory where extracted images are saved when using
                 image_output="external". Default: None (images saved alongside
                 output files in a temporary directory).
-            sanitize: Enable sensitive data sanitization. Replaces emails,
-                phone numbers, IPs, credit cards, and URLs with placeholders.
+            sanitize: Enable sensitive data sanitization. Default: False.
+                Replaces emails, phone numbers, IPs, credit cards, and URLs
+                with placeholders.
             pages: Pages to extract (e.g., "1,3,5-7"). Default: all pages.
             include_header_footer: Include page headers and footers in output.
+                Default: False.
+            detect_strikethrough: Detect strikethrough text and wrap with ~~
+                in Markdown output (experimental). Default: False.
             split_pages: If True, split output into separate Documents per page.
-                Automatically sets the appropriate page separator for the format.
+                Default: True. Automatically sets the appropriate page separator
+                for the format.
             hybrid: Backend for hybrid AI extraction. None = Java-only (default).
                 Values: "docling-fast". Requires a running hybrid backend server.
             hybrid_mode: Triage mode when hybrid is enabled. Default: None
@@ -254,32 +261,40 @@ class OpenDataLoaderPDFLoader(BaseLoader):
                 # Get page separator for split_pages mode
                 page_sep = self._get_page_separator()
 
+                # --- BEGIN SYNCED CONVERT KWARGS ---
+                convert_kwargs = {
+                    "format": [self.format],
+                    "quiet": self.quiet,
+                    "content_safety_off": self.content_safety_off,
+                    "password": self.password,
+                    "keep_line_breaks": self.keep_line_breaks,
+                    "replace_invalid_chars": self.replace_invalid_chars,
+                    "use_struct_tree": self.use_struct_tree,
+                    "table_method": self.table_method,
+                    "reading_order": self.reading_order,
+                    "image_output": self.image_output,
+                    "image_format": self.image_format,
+                    "image_dir": self.image_dir,
+                    "sanitize": self.sanitize,
+                    "pages": self.pages,
+                    "include_header_footer": self.include_header_footer,
+                    "detect_strikethrough": self.detect_strikethrough,
+                    "hybrid": self.hybrid,
+                    "hybrid_mode": self.hybrid_mode,
+                    "hybrid_url": self.hybrid_url,
+                    "hybrid_timeout": self.hybrid_timeout,
+                    "hybrid_fallback": self.hybrid_fallback,
+                }
+                # --- END SYNCED CONVERT KWARGS ---
+                # Omit None values so the core engine applies its own defaults.
+                # Boolean False and explicit values (e.g., image_output="off")
+                # are intentionally kept to pin the wrapper's chosen defaults.
+                convert_kwargs = {k: v for k, v in convert_kwargs.items() if v is not None}
+
                 opendataloader_pdf.convert(
                     input_path=self.file_paths,
                     output_dir=output_dir,
-                    # --- BEGIN SYNCED CONVERT KWARGS ---
-                    format=[self.format],
-                    quiet=self.quiet,
-                    content_safety_off=self.content_safety_off,
-                    password=self.password,
-                    keep_line_breaks=self.keep_line_breaks,
-                    replace_invalid_chars=self.replace_invalid_chars,
-                    use_struct_tree=self.use_struct_tree,
-                    table_method=self.table_method,
-                    reading_order=self.reading_order,
-                    image_output=self.image_output,
-                    image_format=self.image_format,
-                    image_dir=self.image_dir,
-                    sanitize=self.sanitize,
-                    pages=self.pages,
-                    include_header_footer=self.include_header_footer,
-                    detect_strikethrough=self.detect_strikethrough,
-                    hybrid=self.hybrid,
-                    hybrid_mode=self.hybrid_mode,
-                    hybrid_url=self.hybrid_url,
-                    hybrid_timeout=self.hybrid_timeout,
-                    hybrid_fallback=self.hybrid_fallback,
-                    # --- END SYNCED CONVERT KWARGS ---
+                    **convert_kwargs,
                     markdown_page_separator=page_sep,
                     text_page_separator=page_sep,
                     html_page_separator=page_sep,
@@ -328,5 +343,4 @@ class OpenDataLoaderPDFLoader(BaseLoader):
             logger.exception("Error processing output files")
             raise
         finally:
-            import shutil
             shutil.rmtree(output_dir, ignore_errors=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "langchain-core>=1.0,<2.0",

--- a/tests/test_document_loaders.py
+++ b/tests/test_document_loaders.py
@@ -908,6 +908,23 @@ class TestOpenDataLoaderPDFLoaderHybridErrors:
         docs = list(loader.lazy_load())
         assert docs == []
 
+    @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
+    @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
+    def test_output_processing_error_reraise(self, mock_mkdtemp, mock_odl, tmp_path):
+        """Output-processing errors (after conversion) must propagate to callers."""
+        mock_mkdtemp.return_value = str(tmp_path)
+        mock_odl.convert = MagicMock()
+
+        # Create a malformed output file that will cause json.loads to fail
+        bad_file = tmp_path / "test.json"
+        bad_file.write_text("not valid json", encoding="utf-8")
+
+        loader = OpenDataLoaderPDFLoader(
+            file_path="test.pdf", format="json", split_pages=True
+        )
+        with pytest.raises(Exception):
+            list(loader.lazy_load())
+
 
 class TestOpenDataLoaderPDFLoaderPathHandling:
     """Test file_path handling with Path objects and convert call."""

--- a/tests/test_document_loaders.py
+++ b/tests/test_document_loaders.py
@@ -922,7 +922,7 @@ class TestOpenDataLoaderPDFLoaderHybridErrors:
         loader = OpenDataLoaderPDFLoader(
             file_path="test.pdf", format="json", split_pages=True
         )
-        with pytest.raises(Exception):
+        with pytest.raises(json.JSONDecodeError):
             list(loader.lazy_load())
 
 

--- a/tests/test_document_loaders.py
+++ b/tests/test_document_loaders.py
@@ -929,7 +929,7 @@ class TestOpenDataLoaderPDFLoaderHybridErrors:
             list(loader.lazy_load())
 
         # Verify tmpdir was cleaned up even after error
-        assert not tmp_path.exists() or not any(tmp_path.iterdir())
+        assert not tmp_path.exists()
 
 
 class TestOpenDataLoaderPDFLoaderPathHandling:

--- a/tests/test_document_loaders.py
+++ b/tests/test_document_loaders.py
@@ -279,7 +279,8 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
         list(loader.lazy_load())
 
         call_kwargs = mock_odl.convert.call_args[1]
-        assert call_kwargs["image_dir"] is None
+        # None values are omitted from kwargs (pass-through to core engine defaults)
+        assert "image_dir" not in call_kwargs
 
     @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
     @patch("langchain_opendataloader_pdf.document_loaders.tempfile.mkdtemp")
@@ -392,10 +393,12 @@ class TestOpenDataLoaderPDFLoaderConvertCall:
         list(loader.lazy_load())
 
         call_kwargs = mock_odl.convert.call_args[1]
-        assert call_kwargs["hybrid"] is None
-        assert call_kwargs["hybrid_mode"] is None
-        assert call_kwargs["hybrid_url"] is None
-        assert call_kwargs["hybrid_timeout"] is None
+        # None values are omitted from kwargs (pass-through to core engine defaults)
+        assert "hybrid" not in call_kwargs
+        assert "hybrid_mode" not in call_kwargs
+        assert "hybrid_url" not in call_kwargs
+        assert "hybrid_timeout" not in call_kwargs
+        # False is not None, so it IS passed
         assert call_kwargs["hybrid_fallback"] is False
 
     @patch("langchain_opendataloader_pdf.document_loaders.opendataloader_pdf")
@@ -924,6 +927,9 @@ class TestOpenDataLoaderPDFLoaderHybridErrors:
         )
         with pytest.raises(json.JSONDecodeError):
             list(loader.lazy_load())
+
+        # Verify tmpdir was cleaned up even after error
+        assert not tmp_path.exists() or not any(tmp_path.iterdir())
 
 
 class TestOpenDataLoaderPDFLoaderPathHandling:


### PR DESCRIPTION
## Summary

- Fix 3 docstring mismatches (`replace_invalid_chars`, `reading_order`, `image_format`) to reflect `None` pass-through pattern instead of hardcoded upstream defaults
- README: remove sync markers from params table, document core engine defaults with "Core engine defaults to X" pattern
- CHANGELOG: add breaking change note for `opendataloader-pdf>=2.1.0`, fix `hybrid_timeout` default description (30000ms, not "0")
- Re-raise exception in `document_loaders.py` L328 instead of silent error swallowing
- Remove Python 3.14 from classifiers (not yet released)

## Context

Post-merge review of PR #16 found that docstrings and documentation were inconsistent with the pass-through default pattern (`None` in wrapper, core engine applies its own defaults). This PR aligns all 4 locations (code defaults, docstrings, README, CHANGELOG) for each parameter.

## Test plan

- [x] `uv run pytest --disable-socket -v` — 79 passed
- [ ] Verify README renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Minimum opendataloader-pdf requirement bumped to >=2.1.0
  * lazy_load() now surfaces output-processing exceptions instead of suppressing them

* **Documentation**
  * Parameter docs updated to show optional/None defaults and core-engine fallback behavior
  * Clarified hybrid timeout default (30s) and hybrid-related defaults

* **Tests**
  * Added test ensuring output-processing errors are propagated

* **Chores**
  * Removed Python 3.14 packaging classifier
<!-- end of auto-generated comment: release notes by coderabbit.ai -->