### PR TITLE
ci: harden workflows against shell injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: '[Python] Build and test'
         run: |
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+          # Defense-in-depth: escape sed metacharacters in VERSION
+          ESCAPED_VER=$(printf '%s\n' "${VERSION}" | sed 's/[&/\]/\\&/g')
+          sed -i "s/^version = \".*\"/version = \"${ESCAPED_VER}\"/" pyproject.toml
           uv build
 
       # =================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: '[Python] Build and test'
         run: |
-          sed -i "s/^version = \".*\"/version = \"${{ env.VERSION }}\"/" pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
           uv build
 
       # =================================================================

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -35,8 +35,8 @@ jobs:
     steps:
       - name: Validate version format
         run: |
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Invalid version format: '$VERSION'. Expected semver (e.g., 2.3.0)"
+          if ! echo "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version format: '${VERSION}'. Expected semver (e.g., 2.3.0)"
             exit 1
           fi
 
@@ -76,12 +76,14 @@ jobs:
             --config upstream/scripts/langchain-sync-config.json \
             --target langchain_opendataloader_pdf/document_loaders.py \
             --readme README.md \
-            --version "$VERSION" \
+            --version "${VERSION}" \
             --pr-body .sync-report/pr-body.md
 
       - name: Update pyproject.toml dependency
         run: |
-          ESCAPED_VER=$(printf '%s\n' "$VERSION" | sed 's/[&/\]/\\&/g')
+          # Defense-in-depth: semver validation above blocks metacharacters,
+          # but escape anyway in case the validation regex is ever relaxed.
+          ESCAPED_VER=$(printf '%s\n' "${VERSION}" | sed 's/[&/\]/\\&/g')
           sed -i "s/\"opendataloader-pdf>=.*\"/\"opendataloader-pdf>=${ESCAPED_VER}\"/" pyproject.toml
 
       - name: Check for changes
@@ -114,14 +116,14 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         id: branch
         run: |
-          BRANCH="sync/v$VERSION"
+          BRANCH="sync/v${VERSION}"
           echo "name=$BRANCH" >> $GITHUB_OUTPUT
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add langchain_opendataloader_pdf/document_loaders.py pyproject.toml README.md
           git add .sync-report/ || true
-          git commit -m "sync: update to opendataloader-pdf v$VERSION"
+          git commit -m "sync: update to opendataloader-pdf v${VERSION}"
           git push origin "$BRANCH" --force-with-lease
 
   # =================================================================
@@ -156,20 +158,20 @@ jobs:
       - name: Wait for PyPI availability
         run: |
           for i in $(seq 1 20); do
-            if pip install --dry-run "opendataloader-pdf==$VERSION" 2>/dev/null; then
-              echo "Version $VERSION available on PyPI"
+            if pip install --dry-run "opendataloader-pdf==${VERSION}" 2>/dev/null; then
+              echo "Version ${VERSION} available on PyPI"
               exit 0
             fi
             echo "Attempt $i/20: waiting 30s..."
             sleep 30
           done
-          echo "::error::PyPI version $VERSION not available after 10 minutes"
+          echo "::error::PyPI version ${VERSION} not available after 10 minutes"
           exit 1
 
       - name: Install dependencies
         run: |
           pip install -e . pytest pytest-socket
-          pip install "opendataloader-pdf>=$VERSION"
+          pip install "opendataloader-pdf>=${VERSION}"
 
       - name: Run unit tests
         run: pytest tests/test_document_loaders.py -v --disable-socket --allow-unix-socket
@@ -244,6 +246,8 @@ jobs:
           LABELS="sync,automated"
           [ "$BREAKING" == "true" ] && LABELS="$LABELS,breaking-change"
 
+          # DRAFT_FLAG intentionally unquoted: empty string must produce
+          # zero arguments, not an empty-string argument that gh rejects.
           gh pr create \
             --title "sync: update to opendataloader-pdf v${VERSION}" \
             --body-file /tmp/pr-body.md \

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -81,7 +81,8 @@ jobs:
 
       - name: Update pyproject.toml dependency
         run: |
-          sed -i "s/\"opendataloader-pdf>=.*\"/\"opendataloader-pdf>=$VERSION\"/" pyproject.toml
+          ESCAPED_VER=$(printf '%s\n' "$VERSION" | sed 's/[&/\]/\\&/g')
+          sed -i "s/\"opendataloader-pdf>=.*\"/\"opendataloader-pdf>=${ESCAPED_VER}\"/" pyproject.toml
 
       - name: Check for changes
         id: changes
@@ -213,13 +214,13 @@ jobs:
         env:
           STATUS_RESULT: ${{ steps.status.outputs.result }}
         run: |
-          cat > /tmp/pr-body.md << ENDOFBODY
-## Sync with opendataloader-pdf v${VERSION}
-
-${STATUS_RESULT}
-
-Auto-generated from [opendataloader-pdf v${VERSION}](https://github.com/opendataloader-project/opendataloader-pdf/releases/tag/v${VERSION}).
-ENDOFBODY
+          {
+            echo "## Sync with opendataloader-pdf v${VERSION}"
+            echo ""
+            echo "${STATUS_RESULT}"
+            echo ""
+            echo "Auto-generated from [opendataloader-pdf v${VERSION}](https://github.com/opendataloader-project/opendataloader-pdf/releases/tag/v${VERSION})."
+          } > /tmp/pr-body.md
 
           if [ "$BREAKING" == "true" ]; then
             echo "" >> /tmp/pr-body.md
@@ -244,11 +245,11 @@ ENDOFBODY
           [ "$BREAKING" == "true" ] && LABELS="$LABELS,breaking-change"
 
           gh pr create \
-            --title "sync: update to opendataloader-pdf v$VERSION" \
+            --title "sync: update to opendataloader-pdf v${VERSION}" \
             --body-file /tmp/pr-body.md \
             --base main \
-            $DRAFT_FLAG \
-            --label "$LABELS"
+            ${DRAFT_FLAG} \
+            --label "${LABELS}"
 
       - name: Notify Slack
         if: always() && env.SLACK_URL != ''


### PR DESCRIPTION
## Summary

- **sync-upstream.yml**: Escape `$VERSION` in sed to prevent special character injection, replace heredoc with echo block to avoid unquoted variable expansion, quote `gh pr create` arguments with `${}`
- **release.yml**: Use shell variable `${VERSION}` instead of `${{ env.VERSION }}` in `run:` block to prevent injection

## Context

Security audit of CI workflows found that `$VERSION` (derived from git tags or workflow inputs) was used unescaped in `sed` patterns and unquoted in shell commands. While git tags are typically controlled, this pattern is vulnerable to special characters (`/`, `&`, `\`) breaking or exploiting `sed` commands.

`${{ env.VERSION }}` in `run:` blocks is a known shell injection vector per [GitHub Security Lab guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/). Using shell variables (`${VERSION}`) from `env:` blocks is the safe pattern.

## Test plan

- [ ] `actionlint .github/workflows/*.yml` passes
- [ ] Trigger `sync-upstream.yml` via `workflow_dispatch` with a test version
- [ ] Verify `release.yml` builds correctly on manual trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow reliability for build/release steps: safer version propagation, more robust handling of special characters in version strings, and more reliable PR creation and messaging.

---

**Note:** This release contains internal infrastructure updates with no user-facing feature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->