### PR TITLE
fix(deps): upgrade Pygments 2.19.2 → 2.20.0 (CVE-2026-4539)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -544,11 +544,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Objective
Dependabot alert #13 reports a ReDoS vulnerability (CVE-2026-4539) in Pygments < 2.20.0.
The inefficient regex in `AdlLexer` allows local denial-of-service via crafted input.

Fixes [opendataloader-project/langchain-opendataloader-pdf Dependabot #13](https://github.com/opendataloader-project/langchain-opendataloader-pdf/security/dependabot/13)

## Approach
Run `uv lock --upgrade-package pygments` to bump the transitive dependency
from 2.19.2 to 2.20.0 — Pygments is not a direct dependency (pulled in via pytest),
so only `uv.lock` changes. No source code modification needed.

## Evidence
Cannot reproduce the ReDoS locally — the vulnerability is in an Archetype lexer
(`AdlLexer`) that this project does not invoke. Evidence is limited to CI verification:

| Scenario | Expected | Actual |
|----------|----------|--------|
| unit-test (3.10, 3.12, 3.13) | Pass | Pending CI |
| min-dep-test | Pass | Pending CI |
| Pygments version in lock | 2.20.0 | 2.20.0 ✅ |