### PR TITLE
chore: add NOTICE file to align with opendataloader-project

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,14 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-This product includes 'LangChain OpenDataLoader PDF' distributed under
-the Apache License 2.0, along with various third-party software
-components. For the complete source code and detailed copyright notices
-and license information for each third-party component, please visit:
-
-    https://github.com/opendataloader-project/langchain-opendataloader-pdf
-
-
 THIRD-PARTY LICENSES
 
 This project includes third-party libraries and components, licensed under

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,31 @@
+LangChain OpenDataLoader PDF
+Copyright 2025-2026 Hancom, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This product includes 'LangChain OpenDataLoader PDF' distributed under
+the Apache License 2.0, along with various third-party software
+components. For the complete source code and detailed copyright notices
+and license information for each third-party component, please visit:
+
+    https://github.com/opendataloader-project/langchain-opendataloader-pdf
+
+
+THIRD-PARTY LICENSES
+
+This project includes third-party libraries and components, licensed under
+their respective open source licenses. For details, see:
+
+    THIRD_PARTY/THIRD_PARTY_LICENSES.md
+    THIRD_PARTY/THIRD_PARTY_NOTICES.md
+    THIRD_PARTY/licenses/


### PR DESCRIPTION
## Objective

Downstream users redistributing the `opendataloader-project` family
(pdf engine + langchain integration + llamaindex reader + bench) face
inconsistent NOTICE expectations. The upstream `opendataloader-pdf`
ships a `NOTICE` file (Apache-2.0 § 4(d) attribution + third-party
pointer), but this repo did not — leaving downstream redistributors
unsure which copyright/notices to carry forward when they ship
`pdf + langchain` together.

## Approach

Add a `NOTICE` file matching the upstream `opendataloader-pdf`
convention:

- Same Apache-2.0 boilerplate, retitled "LangChain OpenDataLoader PDF".
- Copyright "Hancom, Inc." consistent with upstream.
- Repo-specific URL.
- Pointer to the existing `THIRD_PARTY/` folder
  (`THIRD_PARTY_LICENSES.md`, `THIRD_PARTY_NOTICES.md`, `licenses/`).

`NOTICE` is not a strict Apache-2.0 requirement (§ 4(d) only obligates
preservation if a NOTICE exists), but adding it keeps the family
consistent and gives downstream redistributors a single, predictable
attribution source.

## Evidence

Metadata-only change; no runtime behavior. Verified via file inspection:

| Scenario                                | Expected                          | Actual                                          |
|-----------------------------------------|-----------------------------------|-------------------------------------------------|
| `NOTICE` present at repo root           | yes                               | yes                                             |
| First line                              | `LangChain OpenDataLoader PDF`    | `LangChain OpenDataLoader PDF`                  |
| Apache-2.0 boilerplate                  | matches upstream pdf NOTICE       | matches (same wording, retitled)                |
| `THIRD_PARTY/` paths referenced exist   | yes                               | yes (`THIRD_PARTY/THIRD_PARTY_*`, `licenses/`)  |
| `LICENSE` / `pyproject` license         | Apache-2.0 (unchanged)            | Apache-2.0 (unchanged)                          |

Companion PRs aligning the rest of the family:
- `opendataloader-bench` MIT → Apache-2.0 + NOTICE: opendataloader-project/opendataloader-bench#19
- `opendataloader-pdf-llamaindex` NOTICE: (separate PR, in flight)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added NOTICE document with copyright information (2025–2026), Apache License 2.0 terms, and details about third-party libraries and components included in the project, with references to dedicated license files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->