### PR TITLE
ci: add Dependabot config (weekly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,35 @@
 version: 2
 updates:
+  # Python package (uv project; Dependabot updates pyproject.toml under the "pip" ecosystem.
+  # Note: it does not refresh uv.lock — run `uv lock` after merging dependency bumps.)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "security"
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Objective
Enable automated dependency updates via Dependabot.

## Approach
Add `.github/dependabot.yml` with a consistent policy across ODL repos:
- **Schedule**: weekly, Monday 09:00 KST
- **Grouping**: minor/patch grouped into one PR; major bumps get their own PR for review
- **Scope**: all dependency manifests in this repo + GitHub Actions (where workflows exist)
- Security updates continue to be PR'd immediately, independent of this schedule

## Evidence
`dependabot.yml` validated as YAML; ecosystems/directories matched against the actual manifest layout in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
